### PR TITLE
Don't shadow the builtin close() for channels

### DIFF
--- a/02_FirstImage/main.go
+++ b/02_FirstImage/main.go
@@ -49,7 +49,7 @@ func loadMedia() error {
 	return nil
 }
 
-func close() {
+func Close() {
 	helloWorld.Free()
 	window.Destroy()
 	sdl.Quit()
@@ -70,5 +70,5 @@ func main() {
 	window.UpdateSurface()
 	sdl.Delay(2000)
 
-	close()
+	Close()
 }

--- a/03_EventDrivenProgramming/main.go
+++ b/03_EventDrivenProgramming/main.go
@@ -51,7 +51,7 @@ func loadMedia() error {
 	return nil
 }
 
-func close() {
+func Close() {
 	helloWorld.Free()
 	window.Destroy()
 	sdl.Quit()
@@ -81,5 +81,5 @@ func main() {
 		}
 	}
 
-	close()
+	Close()
 }

--- a/04_KeyPresses/main.go
+++ b/04_KeyPresses/main.go
@@ -92,7 +92,7 @@ func loadMedia() error {
 	return nil
 }
 
-func close() {
+func Close() {
 
 	window.Destroy()
 	sdl.Quit()
@@ -136,5 +136,5 @@ func main() {
 		window.UpdateSurface()
 	}
 
-	close()
+	Close()
 }

--- a/05_OptimizedSurfaceLoadingAndSoftStretching/main.go
+++ b/05_OptimizedSurfaceLoadingAndSoftStretching/main.go
@@ -69,7 +69,7 @@ func loadMedia() error {
 	return nil
 }
 
-func close() {
+func Close() {
 
 	window.Destroy()
 	sdl.Quit()
@@ -105,5 +105,5 @@ func main() {
 		}
 	}
 
-	close()
+	Close()
 }

--- a/06_LoadingOtherImageFormats/main.go
+++ b/06_LoadingOtherImageFormats/main.go
@@ -77,7 +77,7 @@ func loadMedia() error {
 	return nil
 }
 
-func close() {
+func Close() {
 
 	window.Destroy()
 	img.Quit()
@@ -114,5 +114,5 @@ func main() {
 		}
 	}
 
-	close()
+	Close()
 }

--- a/07_TextureLoadingAndRendering/main.go
+++ b/07_TextureLoadingAndRendering/main.go
@@ -80,7 +80,7 @@ func loadMedia() error {
 	return nil
 }
 
-func close() {
+func Close() {
 	texture.Destroy()
 	renderer.Destroy()
 	window.Destroy()
@@ -113,5 +113,5 @@ func main() {
 		renderer.Present()
 	}
 
-	close()
+	Close()
 }

--- a/08_GeometryRendering/main.go
+++ b/08_GeometryRendering/main.go
@@ -76,7 +76,7 @@ func loadMedia() error {
 	return nil
 }
 
-func close() {
+func Close() {
 	texture.Destroy()
 	renderer.Destroy()
 	window.Destroy()
@@ -126,5 +126,5 @@ func main() {
 		renderer.Present()
 	}
 
-	close()
+	Close()
 }

--- a/09_TheViewport/main.go
+++ b/09_TheViewport/main.go
@@ -80,7 +80,7 @@ func loadMedia() error {
 	return nil
 }
 
-func close() {
+func Close() {
 	texture.Destroy()
 	renderer.Destroy()
 	window.Destroy()
@@ -126,5 +126,5 @@ func main() {
 		renderer.Present()
 	}
 
-	close()
+	Close()
 }


### PR DESCRIPTION
[`close()`](https://godoc.org/builtin#close) might not be used in your examples, but it could lead to confusion later on